### PR TITLE
temporary fix of tanh

### DIFF
--- a/src/Torch/Layer/LSTM.hs
+++ b/src/Torch/Layer/LSTM.hs
@@ -46,10 +46,10 @@ lstmCell LSTMParams{..} (ct,ht) xt =
   let xt_ht = cat (Dim 0) [xt,ht]
       ft = sigmoid $ linearLayer forgetGate $ xt_ht
       it = sigmoid $ linearLayer inputGate $ xt_ht
-      cant = tanh $ linearLayer candidateGate $ xt_ht
+      cant = tanh' $ linearLayer candidateGate $ xt_ht
       ct' = (ft * ct) + (it * cant)
       ot = sigmoid $ linearLayer outputGate $ xt_ht
-      ht' = ot * (tanh ct')
+      ht' = ot * (tanh' ct')
   in (ct', ht')
 
 -- | inputのlistから、(cellState,hiddenState=output)のリストを返す
@@ -62,3 +62,6 @@ bilstmLayer params c0 h0 inputs =
   let firstLayer = tail $ scanl' (lstmCell params) (c0,h0) inputs in
   reverse $ tail $ scanl' (lstmCell params) (last firstLayer) $ reverse $ snd $ unzip firstLayer
 
+-- | HACK : Torch.Functional.tanhとexpが `Segmentation fault`になるため
+tanh' :: Tensor -> Tensor
+tanh' x = 2 * (sigmoid $ 2 * x) - 1


### PR DESCRIPTION
tanhで`segmentation fault` となるため、回避策としてtanh'を追加