### PR TITLE
added stacked bidirectional RNN as Torch.Layer.RNN

### DIFF
--- a/hasktorch-tools.cabal
+++ b/hasktorch-tools.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: e6f6664d1eed5028f046217a4707e07500354fbd63fe49d1b83cd6b188e8c95b
+-- hash: add34cc83dbafac32c97172bdc06927ade56c1ca5a70c327bed3dc5ad827e9a9
 
 name:           hasktorch-tools
 version:        0.2.0.7
@@ -32,10 +32,12 @@ library
       Torch.Control
       Torch.Train
       Torch.Layer.Linear
+      Torch.Layer.NonLinear
       Torch.Layer.MLP
       Torch.Layer.RNN
       Torch.Layer.LSTM
       Torch.Layer.SimpleLSTM
+      Torch.Layer.ProtoType.RNN
       Torch.Layer.ProtoType.LSTM
       Torch.Tensor.TensorFactories
       Torch.Tensor.Initializers
@@ -247,13 +249,13 @@ test-suite lstmTest
     , zlib >=0.6
   default-language: Haskell2010
 
-test-suite singleLstmLayerTest
+test-suite rnnTest
   type: exitcode-stdio-1.0
   main-is: Main.hs
   other-modules:
       Paths_hasktorch_tools
   hs-source-dirs:
-      test/singleLstmLayerTest
+      test/rnnTest
   ghc-options: -Wall -threaded -rtsopts -with-rtsopts=-N
   build-depends:
       HUnit >=1.6.0

--- a/package.yaml
+++ b/package.yaml
@@ -61,10 +61,12 @@ library:
   - Torch.Control
   - Torch.Train
   - Torch.Layer.Linear
+  - Torch.Layer.NonLinear
   - Torch.Layer.MLP
   - Torch.Layer.RNN
   - Torch.Layer.LSTM
   - Torch.Layer.SimpleLSTM
+  - Torch.Layer.ProtoType.RNN
   - Torch.Layer.ProtoType.LSTM
   - Torch.Tensor.TensorFactories
   - Torch.Tensor.Initializers
@@ -165,13 +167,27 @@ executables:
 #      - hasktorch-tools
 #      - containers >= 0.6
 tests:
-  singleLstmLayerTest:
+#  singleRnnLayerTest:
+#    main:         Main.hs
+#    source-dirs:  test/singleRnnLayerTest
+#    ghc-options:  [-threaded, -rtsopts, -with-rtsopts=-N]
+#    dependencies: 
+#      - hasktorch-tools
+#      - HUnit >= 1.6.0
+  rnnTest:
     main:         Main.hs
-    source-dirs:  test/singleLstmLayerTest
+    source-dirs:  test/rnnTest
     ghc-options:  [-threaded, -rtsopts, -with-rtsopts=-N]
     dependencies: 
       - hasktorch-tools
       - HUnit >= 1.6.0
+#  singleLstmLayerTest:
+#    main:         Main.hs
+#    source-dirs:  test/singleLstmLayerTest
+#    ghc-options:  [-threaded, -rtsopts, -with-rtsopts=-N]
+#    dependencies: 
+#      - hasktorch-tools
+#      - HUnit >= 1.6.0
   lstmTest:
     main:         Main.hs
     source-dirs:  test/lstmTest

--- a/src/Torch/Layer/Linear.hs
+++ b/src/Torch/Layer/Linear.hs
@@ -12,7 +12,7 @@ module Torch.Layer.Linear (
 
 import GHC.Generics                       --base
 import Data.List        (singleton)       --base
-import Control.Monad    (when,unless)     --base
+import Control.Monad    (unless)     --base
 import System.IO.Unsafe (unsafePerformIO) --base
 --hasktorch
 import Torch.Tensor          (Tensor(..),toCPU,shape,reshape)

--- a/src/Torch/Layer/NonLinear.hs
+++ b/src/Torch/Layer/NonLinear.hs
@@ -1,0 +1,28 @@
+{-# LANGUAGE DeriveGeneric #-}
+
+module Torch.Layer.NonLinear (
+  ActName(..),
+  decodeAct
+  ) where
+
+import Prelude hiding (tanh)
+import GHC.Generics              --base
+import qualified Data.Aeson as A --aeson
+import Torch.Tensor (Tensor(..)) --hasktorch
+import Torch.Functional   (sigmoid,relu,elu',selu) --hasktorch
+
+data ActName = Id | Sigmoid | Tanh | Relu | Elu | Selu deriving (Eq,Show,Read,Generic)
+
+instance A.FromJSON ActName
+instance A.ToJSON ActName
+
+decodeAct :: ActName -> Tensor -> Tensor
+decodeAct actname = case actname of
+                   Id  -> id
+                   Sigmoid -> sigmoid
+                   Tanh -> tanh
+                   Relu -> relu
+                   Elu -> elu'
+                   Selu -> selu
+  -- | HACK : Torch.Functional.tanhとexpが `Segmentation fault`になるため
+  where tanh x = 2 * (sigmoid $ 2 * x) - 1

--- a/src/Torch/Layer/ProtoType/LSTM.hs
+++ b/src/Torch/Layer/ProtoType/LSTM.hs
@@ -17,11 +17,10 @@ import Data.List (scanl',foldl') --base
 import Control.Monad (forM)      --base
 --hasktorch
 import Torch.Tensor       (Tensor(..))
-import Torch.Functional   (Dim(..),sigmoid,cat,stack)
+import Torch.Functional   (Dim(..),sigmoid,cat)
 import Torch.Device       (Device(..))
 import Torch.NN           (Parameterized(..),Randomizable(..),Parameter,sample)
-import Torch.Autograd (IndependentTensor(..),makeIndependent)
-import Torch.Tensor.Util (unstack)
+import Torch.Autograd     (IndependentTensor(..),makeIndependent)
 import Torch.Tensor.TensorFactories (randnIO')
 import Torch.Layer.Linear (LinearHypParams(..),LinearParams(..),linearLayer)
 

--- a/src/Torch/Layer/ProtoType/RNN.hs
+++ b/src/Torch/Layer/ProtoType/RNN.hs
@@ -1,0 +1,59 @@
+{-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE DeriveAnyClass #-}
+
+module Torch.Layer.ProtoType.RNN (
+  RNNHypParams(..),
+  RNNParams(..),
+  rnnLayer,
+) where
+
+import GHC.Generics                       --base
+import System.IO.Unsafe (unsafePerformIO) --base
+--hasktorch
+import Torch
+--hasktorch-tools
+import Torch.Layer.Linear (LinearHypParams(..),LinearParams(..),linearLayer)
+import Torch.Tensor.Util (unstack)
+
+data RNNHypParams = RNNHypParams
+  { 
+    dev :: Device,
+    inputDim :: Int,
+    hiddenDim :: Int
+  }
+
+data RNNParams = RNNParams
+  { inh :: LinearParams,
+    hh :: LinearParams
+  } deriving (Show, Generic, Parameterized)
+
+instance Randomizable RNNHypParams RNNParams where
+  sample RNNHypParams {..} =
+    RNNParams
+      <$> sample (LinearHypParams dev True inputDim hiddenDim)
+      <*> sample (LinearHypParams dev True hiddenDim hiddenDim)
+
+rnnCell :: 
+  RNNParams ->
+  -- h_t-1
+  Tensor  ->
+  -- x_t
+  Tensor ->
+  -- h_t
+  Tensor
+rnnCell RNNParams {..} ht xt =
+  Torch.tanh ( linearLayer inh xt + linearLayer hh ht)
+
+rnnLayer :: RNNParams -- ^ model
+  -> Tensor           -- ^ h_0 of shape [hiddenDim]
+  -> Maybe Double     -- ^ dropout
+  -> Tensor           -- ^ input tensor of shape [seqLen, inputDim]
+  -> (Tensor, Tensor) -- ^ (output, h_last) of shape [seqLen, hiddenDim] and [hiddenDim]
+rnnLayer model h0 dropoutProb input =
+  let dropoutLayer = case dropoutProb of
+                       Just prob -> unsafePerformIO . (dropout prob True)
+                       Nothing -> id
+      hidden = unstack $ dropoutLayer $ stack (Dim 0) $ scanl (rnnCell model) h0 $ unstack input
+  in (stack (Dim 0) $ tail hidden, last hidden)

--- a/src/Torch/Layer/RNN.hs
+++ b/src/Torch/Layer/RNN.hs
@@ -52,11 +52,11 @@ instance Parameterized SingleRnnParams
 rnnCell :: SingleRnnParams 
   -> Tensor -- ^ ht of shape <hDim>
   -> Tensor -- ^ xt of shape <iDim/oDim>
-  -> Tensor -- ht' of shape <hDim>
+  -> Tensor -- ^ ht' of shape <hDim>
 rnnCell SingleRnnParams{..} ht xt = linearLayer rnnGate $ cat (Dim 0) [xt,ht]
 
 -- | inputのlistから、(cellState,hiddenState=output)のリストを返す
--- | （lstmLayersのサブルーチン。外部から使う想定ではない）
+-- | （rnLayersのサブルーチン。外部から使う想定ではない）
 -- | scanl'の型メモ :: ((h,c) -> input -> (h',c')) -> (h0,c0) -> [input] -> [(hi,ci)]
 singleRnnLayer :: Bool -- ^ bidirectional (True if bidirectioal, False otherwise)
   -> Int               -- ^ stateDim (=hDim)

--- a/src/Torch/Layer/RNN.hs
+++ b/src/Torch/Layer/RNN.hs
@@ -1,59 +1,181 @@
-{-# LANGUAGE RecordWildCards #-}
-{-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE DeriveGeneric #-}
-{-# LANGUAGE DeriveAnyClass #-}
+{-# LANGUAGE DuplicateRecordFields #-}
+
+{- Throuout the comments, a tensor of shape [a,b,..] is written as <a,b,...> -}
 
 module Torch.Layer.RNN (
-  RNNHypParams(..),
-  RNNParams(..),
-  rnnLayer,
-) where
+  RnnHypParams(..)
+  , RnnParams(..)
+  , singleRnnLayer
+  , rnnLayers
+  , InitialStatesHypParams(..)
+  , InitialStatesParams(..)
+  ) where 
 
-import GHC.Generics                       --base
+import Prelude hiding   (tanh) 
+import GHC.Generics              --base
+import Data.Function    ((&))    --base
+import Data.Maybe       (isJust) --base
+import Data.List        (scanl',foldl',scanr) --base
+import Control.Monad    (forM,unless)     --base
 import System.IO.Unsafe (unsafePerformIO) --base
 --hasktorch
-import Torch
+import Torch.Tensor      (Tensor(..),shape,select,sliceDim,reshape)
+import Torch.Functional  (Dim(..),add,sigmoid,cat,stack,dropout,transpose)
+import Torch.Device      (Device(..))
+import Torch.NN          (Parameterized(..),Randomizable(..),Parameter,sample)
+import Torch.Autograd    (makeIndependent)
 --hasktorch-tools
-import Torch.Layer.Linear (LinearHypParams(..),LinearParams(..),linearLayer)
 import Torch.Tensor.Util (unstack)
+import Torch.Tensor.TensorFactories (randintIO')
+import Torch.Layer.Linear (LinearHypParams(..),LinearParams(..),linearLayer)
+import Torch.Layer.NonLinear (ActName(..),decodeAct)
 
-data RNNHypParams = RNNHypParams
-  { 
-    dev :: Device,
-    inputDim :: Int,
-    hiddenDim :: Int
-  }
+(.->) :: a -> (a -> b) -> b
+(.->) = (&)
 
-data RNNParams = RNNParams
-  { inh :: LinearParams,
-    hh :: LinearParams
-  } deriving (Show, Generic, Parameterized)
+data RnnHypParams = RnnHypParams {
+  dev :: Device
+  , bidirectional :: Bool -- ^ True if BiLSTM, False otherwise
+  , inputSize :: Int  -- ^ The number of expected features in the input x
+  , hiddenSize :: Int -- ^ The number of features in the hidden state h
+  , numLayers :: Int  -- ^ Number of recurrent layers
+  , hasBias :: Bool   -- ^ If False, then the layer does not use bias weights b_ih and b_hh.
+  -- , batch_first :: Bool -- ^ If True, then the input and output tensors are provided as (batch, seq, feature) instead of (seq, batch, feature).
+  } deriving (Eq, Show)
 
-instance Randomizable RNNHypParams RNNParams where
-  sample RNNHypParams {..} =
-    RNNParams
-      <$> sample (LinearHypParams dev True inputDim hiddenDim)
-      <*> sample (LinearHypParams dev True hiddenDim hiddenDim)
+newtype SingleRnnParams = SingleRnnParams {
+    rnnGate :: LinearParams
+    } deriving (Show, Generic)
+instance Parameterized SingleRnnParams
 
-rnnCell :: 
-  RNNParams ->
-  -- h_t-1
-  Tensor  ->
-  -- x_t
-  Tensor ->
-  -- h_t
-  Tensor
-rnnCell RNNParams {..} ht xt =
-  Torch.tanh ( linearLayer inh xt + linearLayer hh ht)
+rnnCell :: SingleRnnParams 
+  -> Tensor -- ^ ht of shape <hDim>
+  -> Tensor -- ^ xt of shape <iDim/oDim>
+  -> Tensor -- ht' of shape <hDim>
+rnnCell SingleRnnParams{..} ht xt = linearLayer rnnGate $ cat (Dim 0) [xt,ht]
 
-rnnLayer :: RNNParams -- ^ model
-  -> Tensor           -- ^ h_0 of shape [hiddenDim]
-  -> Maybe Double     -- ^ dropout
-  -> Tensor           -- ^ input tensor of shape [seqLen, inputDim]
-  -> (Tensor, Tensor) -- ^ (output, h_last) of shape [seqLen, hiddenDim] and [hiddenDim]
-rnnLayer model h0 dropoutProb input =
-  let dropoutLayer = case dropoutProb of
+-- | inputのlistから、(cellState,hiddenState=output)のリストを返す
+-- | （lstmLayersのサブルーチン。外部から使う想定ではない）
+-- | scanl'の型メモ :: ((h,c) -> input -> (h',c')) -> (h0,c0) -> [input] -> [(hi,ci)]
+singleRnnLayer :: Bool -- ^ bidirectional (True if bidirectioal, False otherwise)
+  -> Int               -- ^ stateDim (=hDim)
+  -> ActName           -- ^ actname (the name of nonlinear function)
+  -> SingleRnnParams   -- ^ singleRnnParams
+  -> Tensor            -- ^ h0: <1,hDim> for one-directional and <2,hDim> for BiLSTM
+  -> Tensor            -- ^ inputs: <seqLen,iDim/oDim> for the 1st-layer/the rest
+  -> (Tensor,Tensor)   -- ^ an output pair (<seqLen,D*oDim>,<D*oDim>)
+singleRnnLayer bidirectional stateDim actname singleRnnParams h0 inputs = unsafePerformIO $ do
+  let h0shape = shape h0
+      [seqLen,_] = shape inputs
+      d = if bidirectional then 2 else 1
+      actf = decodeAct actname
+  unless (h0shape == [d,stateDim]) $ ioError $ userError $ "illegal shape of h0: " ++ (show h0shape) 
+  if bidirectional -- check the well-formedness of the shapes of h0 and c0
+    then do -- the case of BiRNN
+      let h0f = select 0 0 h0 -- | pick the first h0 for the forward cells
+          h0b = select 0 1 h0 -- | pick the second h0 for the backward cells
+          hsForward = inputs  -- | <seqLen,iDim/oDim> 
+            .-> unstack       -- | [<iDim/oDim>] of length seqLen
+            .-> scanl' (rnnCell singleRnnParams) h0f -- | [<hDim>] of length seqLen+1
+            .-> tail          -- | [<hDim>] of length seqLen (by removing h0f)
+            .-> stack (Dim 0) -- | <seqLen, hDim>
+          hsBackward = inputs -- | <seqLen,iDim/oDim> 
+            .-> unstack       -- | [<iDim/oDim>] of length seqLen
+            .-> scanr (flip $ rnnCell singleRnnParams) h0b -- | [<hDim>] of length seqLen+1
+            .-> init          -- | [<hDim>] of length seqLen (by removing h0b)
+            .-> stack (Dim 0) -- | <seqLen, hDim>
+          output = [hsForward, hsBackward]   -- | [<seqLen, hDim>] of length 2
+            .-> stack (Dim 0)                -- | <2, seqLen, hDim>
+            .-> actf                         -- | <2, seqLen, hDim> ??
+            .-> transpose (Dim 0) (Dim 1)    -- | <seqLen, 2, hDim>
+            .-> reshape [seqLen, 2*stateDim] -- | <seqLen, 2*hDim>
+          hLast = output                           -- | <seqLen, 2*hDim>
+            .-> sliceDim 0 (seqLen-1) seqLen 1     -- | <1, 2*hDim>
+            .-> (\o -> reshape (tail $ shape o) o) -- | <2*hDim> 
+      return (output, hLast)
+    else do -- the case of RNN
+      let h0f = select 0 0 h0
+          output = inputs
+            .-> unstack          -- | [<iDim/oDim>] of length seqLen
+            .-> scanl' (rnnCell singleRnnParams) h0f -- | [<hDim>] of length seqLen+1
+            .-> tail             -- | [<hDim>] of length seqLen (by removing h0)
+            .-> stack (Dim 0)    -- | <seqLen, hDim>
+            .-> actf             -- | <seqLen, hDim> ??
+          hLast = output                           -- | <seqLen, hDim>
+            .-> sliceDim 0 (seqLen-1) seqLen 1     -- | <1, hDim>
+            .-> (\o -> reshape (tail $ shape o) o) -- | <hDim>
+      return (output, hLast)
+
+data RnnParams = RnnParams {
+  firstRnnParams :: SingleRnnParams    -- ^ a model for the first RNN layer
+  , restRnnParams :: [SingleRnnParams] -- ^ models for the rest of RNN layers
+  } deriving (Show, Generic)
+instance Parameterized RnnParams
+
+instance Randomizable RnnHypParams RnnParams where
+  sample RnnHypParams{..} = do
+    let xDim = inputSize
+        hDim = hiddenSize
+        xh1Dim = xDim + hDim
+        d = if bidirectional then 2 else 1
+        xh2Dim = (d * hDim) + hDim
+    RnnParams
+      <$> (SingleRnnParams <$> sample (LinearHypParams dev hasBias xh1Dim hDim)) -- gate
+      <*> forM [2..numLayers] (\_ ->
+        SingleRnnParams <$> sample (LinearHypParams dev hasBias xh2Dim hDim)
+        )
+
+-- | The main function for RNN layers
+rnnLayers :: RnnParams -- ^ parameters (=model)
+  -> ActName         -- ^ name of nonlinear function
+  -> Maybe Double    -- ^ introduces a Dropout layer on the outputs of each LSTM layer except the last layer, with dropout probability equal to dropout.
+  -> Tensor          -- ^ an initial tensor: <D*numLayers,hDim>
+  -> Tensor          -- ^ an input tensor <seqLen,iDim>
+  -> (Tensor,Tensor) -- ^ an output of (<seqLen,D*oDim>,(<D*numLayers,oDim>,<D*numLayers,cDim>))
+rnnLayers RnnParams{..} actname dropoutProb h0 inputs = unsafePerformIO $ do
+  let numLayers = length restRnnParams + 1
+      (dnumLayers:(hiddenSize:_)) = shape h0
+  unless (dnumLayers == numLayers * 2 || dnumLayers == numLayers) $ 
+    ioError $ userError $ "illegal shape of h0: dnumLayers = " ++ (show dnumLayers) ++ "\nnumLayers = " ++ (show numLayers) 
+  let bidirectional | dnumLayers == numLayers * 2 = True
+                    | dnumLayers == numLayers = False
+                    | otherwise = False -- Unexpected
+      d = if bidirectional then 2 else 1
+      (h0h:h0t) = [sliceDim 0 (d*i) (d*(i+1)) 1 h0 | i <- [0..numLayers]]
+      firstLayer = singleRnnLayer bidirectional hiddenSize actname firstRnnParams h0h
+      restOfLayers = map (uncurry $ singleRnnLayer bidirectional hiddenSize actname) $ zip restRnnParams h0t 
+      dropoutLayer = case dropoutProb of
                        Just prob -> unsafePerformIO . (dropout prob True)
                        Nothing -> id
-      hidden = unstack $ dropoutLayer $ stack (Dim 0) $ scanl (rnnCell model) h0 $ unstack input
-  in (stack (Dim 0) $ tail hidden, last hidden)
+      stackedLayers = \inputTensor -> 
+                        scanr
+                          (\nextLayer ohc -> nextLayer $ dropoutLayer $ fst ohc)
+                          (firstLayer inputTensor) -- (<seqLen,D*oDim>,(<D*oDim>,<D*cDim>))
+                          restOfLayers -- 
+      (outputList, hn) = inputs -- | <seqLen,iDim>
+        .-> stackedLayers       -- | [(<seqLen, D*oDim>,<D*oDim>)] of length numLayers
+        .-> unzip               -- | ([<seqLen, D*oDim>] of length numLayers, [(<D*oDim>,<D*cDim>)] of length numLayers)
+      output = head outputList  -- | [<seqLen, D*oDim>] of length numLayers
+      rh = hn                                      -- | 
+           .-> stack (Dim 0)                       -- | <numLayers, D*oDim/cDim>
+           .-> reshape [d * numLayers, hiddenSize] -- | <D*numLayers, oDim/cDim>
+  return (output, rh)
+
+data InitialStatesHypParams = InitialStatesHypParams {
+  dev :: Device
+  , bidirectional :: Bool
+  , hiddenSize :: Int
+  , numLayers :: Int
+  } deriving (Eq, Show)
+
+newtype InitialStatesParams = InitialStatesParams {
+  h0s :: Parameter 
+  } deriving (Show, Generic)
+instance Parameterized InitialStatesParams
+
+instance Randomizable InitialStatesHypParams InitialStatesParams where
+  sample InitialStatesHypParams{..} = 
+    InitialStatesParams
+      <$> (makeIndependent =<< randintIO' dev (-1) 1 [(if bidirectional then 2 else 1) * numLayers, hiddenSize])
+

--- a/test/rnnTest/Main.hs
+++ b/test/rnnTest/Main.hs
@@ -1,0 +1,81 @@
+{-# LANGUAGE MultiParamTypeClasses, DeriveGeneric, RecordWildCards #-}
+
+module Main where
+
+import GHC.Generics               --base
+import Control.Monad      (forM_) --base
+import Test.HUnit.Base    (Test(..),(~:),assertEqual) --HUnit
+import Test.HUnit.Text    (runTestTT)     --HUnit
+--hasktorch 
+import Torch.Tensor       (shape)
+import Torch.Functional   (mseLoss)
+import Torch.Device       (Device(..),DeviceType(..))
+import Torch.NN           (Parameterized(..),Randomizable(..),sample)
+import Torch.Optim        (GD(..))
+import Torch.Autograd     (IndependentTensor(..))
+--hasktorch-tools
+import Torch.Train        (update)
+import Torch.Tensor.TensorFactories (randnIO')
+import Torch.Layer.RNN   (RnnHypParams(..),InitialStatesHypParams(..),RnnParams(..),InitialStatesParams(..),rnnLayers)
+import Torch.Layer.NonLinear (ActName(..))
+
+data HypParams = HypParams {
+    dev :: Device,
+    inputDim :: Int,
+    hiddenDim :: Int,
+    isBidirectional ::  Bool,
+    hasBias :: Bool,
+    numOfLayers :: Int,
+    dropout :: Maybe Double
+    } deriving (Eq, Show)
+
+data Params = Params {
+  iParams :: InitialStatesParams,
+  rParams :: RnnParams
+  } deriving (Show, Generic)
+instance Parameterized Params
+
+instance Randomizable HypParams Params where
+  sample HypParams{..} = Params
+      <$> (sample $ InitialStatesHypParams dev isBidirectional hiddenDim numOfLayers)
+      <*> (sample $ RnnHypParams dev isBidirectional inputDim hiddenDim numOfLayers True)
+
+-- | Test code to check the shapes of output tensors for the cases of
+-- |   bidirectional True/False | numOfLayers 1,2,3 | dropout on/off | projDim on/off
+main :: IO()
+main = do
+  let dev = Device CUDA 0
+      iDim = 2
+      hDim = 5
+      isBidirectionalAlt = [True, False]
+      hasBiasAlt = [True, False]
+      numOfLayersAlt = [1,2,3]
+      dropoutAlt = [Nothing, Just 0.5]
+      actNameAlt = [Sigmoid,Tanh]--,Relu,Elu,Selu,Id]
+      seqLen = 11
+  forM_ (do
+         x <- isBidirectionalAlt
+         y <- hasBiasAlt
+         z <- numOfLayersAlt
+         u <- dropoutAlt
+         a <- actNameAlt
+         return (x,y,z,u,a)) $ \(isBidirectional, hasBias, numOfLayers, dropout, actName) -> do
+    putStr $ "Setting: isBidirectional = " ++ (show isBidirectional)
+    putStr $ " / hasBias = " ++ (show hasBias)
+    putStr $ " / numOfLayers = " ++ (show numOfLayers)
+    putStr $ " / dropout = " ++ (show dropout)
+    putStr $ " / actName = " ++ (show actName) ++ "\n\n"
+    let hypParams = HypParams dev iDim hDim isBidirectional hasBias numOfLayers dropout
+        d = if isBidirectional then 2 else 1
+    initialParams <- sample hypParams
+    inputs <- randnIO' dev [seqLen,iDim]
+    gt     <- randnIO' dev [seqLen,d * hDim]
+    let rnnOut = fst $ rnnLayers (rParams initialParams) actName dropout (toDependent $ h0s $ iParams initialParams) inputs
+        loss = mseLoss rnnOut gt
+    (u,_) <- update initialParams GD loss 5e-1
+    let (output,hn) = rnnLayers (rParams u) actName dropout (toDependent $ h0s $ iParams u) inputs
+    _ <- runTestTT $ TestList [
+      "A" ~: assertEqual "shape of output" [seqLen, d * hDim] (shape output),
+      "B" ~: assertEqual "shape of h_n" [d * numOfLayers, hDim] (shape hn)
+      ]
+    putStrLn "Case clear.\n"

--- a/test/singleRnnLayerTest/Main.hs
+++ b/test/singleRnnLayerTest/Main.hs
@@ -1,0 +1,85 @@
+{-# LANGUAGE MultiParamTypeClasses, DeriveGeneric, RecordWildCards #-}
+
+module Main where
+
+import GHC.Generics               --base
+import Control.Monad      (forM_) --base
+import Test.HUnit.Base    (Test(..),(~:),assertEqual) --HUnit
+import Test.HUnit.Text    (runTestTT)     --HUnit
+--hasktorch 
+import Torch.Tensor       (shape,sliceDim)
+import Torch.Functional   (mseLoss,matmul)
+import Torch.Device       (Device(..),DeviceType(..))
+import Torch.NN           (Parameterized(..),Randomizable(..),sample)
+import Torch.Optim        (GD(..))
+import Torch.Autograd     (IndependentTensor(..))
+--hasktorch-tools
+import Torch.Train        (update)
+import Torch.Tensor.TensorFactories (randnIO')
+import Torch.Layer.Linear (LinearHypParams(..),linearLayer)
+import Torch.Layer.RNN   (RnnHypParams(..),InitialStatesHypParams(..),RnnParams(..),InitialStatesParams(..),singleRnnLayer)
+import Torch.Layer.NonLinear (ActName(..))
+
+data HypParams = HypParams {
+    dev :: Device,
+    inputDim :: Int,
+    hiddenDim :: Int,
+    isBidirectional ::  Bool,
+    hasBias :: Bool,
+    numOfLayers :: Int,
+    dropout :: Maybe Double
+    } deriving (Eq, Show)
+
+data Params = Params {
+  iParams :: InitialStatesParams,
+  rParams :: RnnParams
+  } deriving (Show, Generic)
+instance Parameterized Params
+
+instance Randomizable HypParams Params where
+  sample HypParams{..} = Params
+      <$> (sample $ InitialStatesHypParams dev isBidirectional hiddenDim numOfLayers)
+      <*> (sample $ RnnHypParams dev isBidirectional inputDim hiddenDim numOfLayers hasBias)
+
+-- | Test code to check the shapes of output tensors for the cases of
+-- |   bidirectional True/False | numOfLayers 1,2,3 | dropout on/off | projDim on/off
+main :: IO()
+main = do
+  let dev = Device CUDA 0
+      iDim = 2
+      hDim = 5
+      isBidirectionalAlt = [True,False]
+      hasBiasAlt = [True, False]
+      numOfLayersAlt = [1,2,3]
+      dropoutAlt = [Nothing, Just 0.5]
+      actAlt = [Sigmoid,Tanh,Relu,Elu,Selu,Id]
+      seqLen = 11
+  forM_ (do
+         x <- isBidirectionalAlt
+         y <- hasBiasAlt
+         z <- numOfLayersAlt
+         u <- dropoutAlt
+         a <- actAlt
+         return (x,y,z,u,a)) $ \(isBidirectional, hasBias, numOfLayers, dropout, actName) -> do
+    putStr $ "Setting: isBiLstm = " ++ (show isBidirectional)
+    putStr $ " / hasBias = " ++ (show hasBias)
+    putStr $ " / numOfLayers = " ++ (show numOfLayers)
+    putStr $ " / dropout = " ++ (show dropout)
+    putStr $ " / actName = " ++ (show actName) ++ "\n\n"
+    let hypParams = HypParams dev iDim hDim isBidirectional hasBias numOfLayers dropout
+        d = if isBidirectional then 2 else 1
+    initialParams <- sample hypParams
+    inputs <- randnIO' dev [seqLen,iDim]
+    gt     <- randnIO' dev [seqLen,hDim]
+    let h0' = toDependent $ h0s $ iParams initialParams
+        h0'' = if isBidirectional
+                 then sliceDim 0 0 2 1 h0'
+                 else sliceDim 0 0 1 1 h0'
+        firstRnnP = firstRnnParams $ rParams initialParams
+        restRnnP = restRnnParams $ rParams initialParams
+        (output, hn) = singleRnnLayer isBidirectional hDim actName firstRnnP h0'' inputs
+    _ <- runTestTT $ TestList [
+      "O" ~: assertEqual "shape of output" [seqLen, d * hDim] (shape output),
+      "H" ~: assertEqual "shape of h_n" [d * hDim] (shape hn)
+      ]
+    putStrLn "Case clear.\n"


### PR DESCRIPTION
Torch.Layer.RNNを追加しました。メインの関数は rnnLayers で、ほぼLSTMと同じ仕様です。

次元数のテストについては 以下の二つを用意してあり、今のところ両方を通っています。

- test/singleRnnLayerTest/Main.hs
- test/rnnLayerTest/Main.hs
