### PR TITLE
update minimum base package version to 4.14

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -15,7 +15,7 @@ description:         https://github.com/DaisukeBekki/hasktorch-tools#readme
 
 dependencies:
 # for hasktorch
-- base >= 4.7 && < 5
+- base >= 4.14 && < 5
 - hasktorch >= 0.2
 - libtorch-ffi 
 - libtorch-ffi-helper


### PR DESCRIPTION
https://github.com/DaisukeBekki/hasktorch-tools/pull/22
singleton関数はbase-4.14.0.0以降で導入されているので、baseのバージョンをアップデートした。